### PR TITLE
fix: Sync active vault counts and fix strategy icon mapping

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -126,7 +126,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head />
+      <head>
+        <link rel="icon" href="/favicon/favicon.ico" />
+        <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png" />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/favicon/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/favicon/favicon-16x16.png"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} bg-app-bg antialiased`}
       >

--- a/components/start-earning-today.tsx
+++ b/components/start-earning-today.tsx
@@ -71,7 +71,10 @@ const StartEarningToday = () => {
       s.isDeprecated ?? s.status?.value?.toLowerCase() === "deprecated";
 
     const activeStrategies = strategies.filter(
-      (s) => !isRetired(s) && !isDeprecated(s)
+      (s) =>
+        !isRetired(s) &&
+        !isDeprecated(s) &&
+        (s.tvlUsd ?? 0) > 0
     );
 
     // Pick one strategy per type (highest numeric APY within each type)

--- a/components/ui/how-it-works-animation.tsx
+++ b/components/ui/how-it-works-animation.tsx
@@ -49,6 +49,31 @@ const FALLBACK_VAULTS: MinimalVault[] = DEFAULT_TOKENS.map((token, index) => ({
   curator: { name: "Troves" },
 }));
 
+/** Maps vault deposit symbol to canonical token key (STRK, BTC, ETH, USDC, USDT) */
+function resolveTokenKeyFromVault(
+  vault: Pick<
+    { name: string; depositToken?: { symbol: string }[] },
+    "name" | "depositToken"
+  >
+): string {
+  const symbol = vault.depositToken?.[0]?.symbol?.toUpperCase();
+  if (symbol) {
+    if (symbol.includes("WBTC") || symbol.includes("BTC")) return "BTC";
+    if (symbol.includes("STRK") || symbol.includes("XSTRK")) return "STRK";
+    if (symbol.includes("ETH") || symbol.includes("WSTETH")) return "ETH";
+    if (symbol === "USDC") return "USDC";
+    if (symbol === "USDT") return "USDT";
+    return symbol;
+  }
+  const name = vault.name?.toUpperCase() ?? "";
+  if (name.includes("WBTC") || name.includes("BTC")) return "BTC";
+  if (name.includes("STRK")) return "STRK";
+  if (name.includes("ETH")) return "ETH";
+  if (name.includes("USDC")) return "USDC";
+  if (name.includes("USDT")) return "USDT";
+  return "STRK";
+}
+
 const HowItWorksAnimation = ({
   className,
   title,
@@ -125,7 +150,10 @@ const HowItWorksAnimation = ({
       const { ringIndex, angleDeg } = ORBITAL_LAYOUT[i];
       const radiusPx = RING_RADII[ringIndex][isDesktop ? 1 : 0];
       const vault = resolvedVaults[i];
-      const token = resolvedTokens[i % resolvedTokens.length];
+      const tokenKey = resolveTokenKeyFromVault(vault);
+      const token =
+        resolvedTokens.find((t) => t.token === tokenKey) ??
+        resolvedTokens[0];
 
       dots.push({
         id: `dot-${i}`,

--- a/types/components.ts
+++ b/types/components.ts
@@ -174,7 +174,7 @@ export interface HowItWorksAnimationProps {
   className?: string;
   title?: string;
   tokens?: TokenInfo[];
-  vaults?: Pick<Strategy, "name" | "apy" | "tvlUsd" | "curator">[];
+  vaults?: Pick<Strategy, "name" | "apy" | "tvlUsd" | "curator" | "depositToken">[];
 }
 
 // provider props


### PR DESCRIPTION
### Summary

Two fixes on the landing page: (1) hero and "Start earning" now use the same active-vault definition, and (2) the how-it-works animation shows the correct token icon per vault.

### Changes

#### Active vault filter sync (`components/start-earning-today.tsx`)

- **Problem:** Hero showed "29 Active vaults" but the button said "View all 31 vaults".
- **Cause:** Hero filtered by `!isRetired && !isDeprecated && (tvlUsd ?? 0) > 0`; start-earning-today only used `!isRetired && !isDeprecated`.
- **Fix:** Both now use the same filter (including `(tvlUsd ?? 0) > 0`).

#### Strategy icon mapping (`components/ui/how-it-works-animation.tsx`)

- **Problem:** "Ekubo WBTC/USDC" tooltip showed the STRK icon instead of BTC.
- **Cause:** Icons were paired with vaults by index (`token[i]` for `vault[i]`), so icons didn't match deposit tokens.
- **Fix:** Each vault resolves its token from `depositToken` or name, and picks the matching icon (e.g. WBTC → BTC, STRK → STRK, ETH → ETH, USDC → USDC, USDT → USDT).

#### Types (`types/components.ts`)

- Extended `HowItWorksAnimationProps` vault type with `depositToken` so the animation can resolve deposit tokens.

### Testing

- Hero "Active vaults" stat and "View all X vaults" button show the same count.
- WBTC/USDC vaults show the BTC icon in the how-it-works radial animation.